### PR TITLE
Improved documentation

### DIFF
--- a/docs/Modpacks/Changes/v1.2.1.md
+++ b/docs/Modpacks/Changes/v1.2.1.md
@@ -33,7 +33,7 @@ In particular, multiblocks supporting parallel hatches now need to be declared d
 // After:
 .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.PERFECT_OVERCLOCK)])
 ```
-Recipe Modifiers must be supplied as a JavaScript array, as this is what Rhino transpiles into a varargs (```RecipeModifier...```) value, which is what the ```.recipeModifiers()``` method accepts as input. If not supplied as an array, Rhino with throw an exception and crash Minecraft.
+Recipe modifiers must be supplied as a JavaScript array, as this is what Rhino transpiles into a varargs (```RecipeModifier...```) value, which is what the ```.recipeModifiers()``` method accepts as input. If not supplied as an array, Rhino with throw an exception and crash Minecraft.
 
 ## Bedrock Ores
 

--- a/docs/Modpacks/Changes/v1.2.1.md
+++ b/docs/Modpacks/Changes/v1.2.1.md
@@ -31,9 +31,9 @@ In particular, multiblocks supporting parallel hatches now need to be declared d
 .recipeModifier(GTRecipeModifiers.PARALLEL_HATCH.apply(OverclockingLogic.PERFECT_OVERCLOCK, GTRecipeModifiers.ELECTRIC_OVERCLOCK))
 
 // After:
-.recipeModifiers(GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.PERFECT_OVERCLOCK))
+.recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.PERFECT_OVERCLOCK)])
 ```
-
+Recipe Modifiers must be supplied as a JavaScript array, as this is what Rhino transpiles into a varargs (```RecipeModifier...```) value, which is what the ```.recipeModifiers()``` method accepts as input. If not supplied as an array, Rhino with throw an exception and crash Minecraft.
 
 ## Bedrock Ores
 

--- a/docs/Modpacks/Other-Topics/Custom-Machines.md
+++ b/docs/Modpacks/Other-Topics/Custom-Machines.md
@@ -21,14 +21,14 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
 
 ```js title="test_electric_machine.js"
 GTCEuStartupEvents.registry('gtceu:machine', event => {
-    event.create('test_electric', 'simple', GTValues.LV, GTValues.MV, GTValues.HV) // (1)
+    event.create('test_electric', 'simple', 0, GTValues.LV, GTValues.MV, GTValues.HV) // (1)
         .rotationState(RotationState.NON_Y_AXIS)
         .recipeType('test_recipe_type')
         .tankScalingFunction(tier => tier * 3200)
 })
 ```
 
-1. Machine ID, Machine Type, Voltage Tiers
+1. Machine ID, Machine Type, Pollution Amount, Voltage Tiers
 
 
 ## Creating Custom Kinetic Machine
@@ -59,6 +59,7 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
 ```js title="test_multiblock.js"
 GTCEuStartupEvents.registry('gtceu:machine', event => {
     event.create('test_generator', 'multiblock')
+        .tooltips(Component.translatable('your.langfile.entry.here')) // (1)
         .rotationState(RotationState.NON_Y_AXIS)
         .appearanceBlock(GTBlocks.CASING_STEEL_SOLID)
         .recipeTypes(['test_recipe_type_1', 'test_recipe_type_2'])
@@ -81,6 +82,8 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
         )
 })
 ```
+
+1. You can add tooltips that are displayed when you mouseover a multiblock controller in your inventory. Each separate call of ```.tooltips()``` will write a separate line to the tooltip. These are read directly from .json lang files you can place in ```kubejs/assets/gtceu/lang```, or can be supplied via a standalone resource pack. The ```Component``` class is autoloaded by KubeJS at script compile time.
 
 ### Shape Info
 

--- a/docs/Modpacks/Other-Topics/Custom-Machines.md
+++ b/docs/Modpacks/Other-Topics/Custom-Machines.md
@@ -21,14 +21,14 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
 
 ```js title="test_electric_machine.js"
 GTCEuStartupEvents.registry('gtceu:machine', event => {
-    event.create('test_electric', 'simple', GTValues.LV, GTValues.MV, GTValues.HV) // (1)
+    event.create('test_electric', 'simple', 0, GTValues.LV, GTValues.MV, GTValues.HV) // (1)
         .rotationState(RotationState.NON_Y_AXIS)
         .recipeType('test_recipe_type')
         .tankScalingFunction(tier => tier * 3200)
 })
 ```
 
-1. Machine ID, Machine Type, Voltage Tiers
+1. Machine ID, Machine Type, Pollution Produced, Voltage Tiers
 
 
 ## Creating Custom Kinetic Machine
@@ -59,6 +59,7 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
 ```js title="test_multiblock.js"
 GTCEuStartupEvents.registry('gtceu:machine', event => {
     event.create('test_generator', 'multiblock')
+        .tooltips(Component.translatable('your.langfile.entry.here')) // (1)
         .rotationState(RotationState.NON_Y_AXIS)
         .appearanceBlock(GTBlocks.CASING_STEEL_SOLID)
         .recipeTypes(['test_recipe_type_1', 'test_recipe_type_2'])
@@ -81,6 +82,8 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
         )
 })
 ```
+
+1. You can add tooltips to your multiblock controllers that show up when you mouseover them. Each separate call of ```.tooltips()``` will add a separate line to the controller's tooltip. ´´´Component.translatable()´´´ reads entries from .json lang files placed in ```kubejs/assets/gtceu/lang``` or supplied via a standalone resource pack. The ```Component``` class is autoloaded by KubeJS at compile time; it doesn't need to be manually loaded.
 
 ### Shape Info
 

--- a/docs/Modpacks/Other-Topics/Custom-Machines.md
+++ b/docs/Modpacks/Other-Topics/Custom-Machines.md
@@ -83,7 +83,7 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
 })
 ```
 
-1. You can add tooltips to your multiblock controllers that show up when you mouseover them. Each separate call of ```.tooltips()``` will add a separate line to the controller's tooltip. ´´´Component.translatable()´´´ reads entries from .json lang files placed in ```kubejs/assets/gtceu/lang``` or supplied via a standalone resource pack. The ```Component``` class is autoloaded by KubeJS at compile time; it doesn't need to be manually loaded.
+1. You can add tooltips to your multiblock controllers that show up when you mouseover them. Each separate call of ```.tooltips()``` will add a separate line to the controller's tooltip. ```Component.translatable()``` reads entries from .json lang files placed in ```kubejs/assets/gtceu/lang``` or supplied via a standalone resource pack. The ```Component``` class is autoloaded by KubeJS at compile time; it doesn't need to be manually loaded.
 
 ### Shape Info
 

--- a/docs/Modpacks/Other-Topics/Custom-Recipe-Types.md
+++ b/docs/Modpacks/Other-Topics/Custom-Recipe-Types.md
@@ -11,15 +11,18 @@ title: Custom Recipe Type
 GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
     event.create('test_recipe_type')
         .category('test')
+        .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.PERFECT_OVERCLOCK)]) // (1)
         .setEUIO('in')
-        .setMaxIOSize(3, 3, 3, 3) // (1)
+        .setMaxIOSize(3, 3, 3, 3) // (2)
         .setSlotOverlay(false, false, GuiTextures.SOLIDIFIER_OVERLAY)
-        .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT)
+        .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT) // (3)
         .setSound(GTSoundEntries.COOLING)
 })
 ```
 
-1. Max Item Inputs, Max Item Outputs, Max Fluid Inputs, Max Fluid Outputs
+1. If electric and/or multiblock machines can process your custom recipe type, ```.recipeModifiers()``` will allow you to fine-tune the behaviour of these machine when running recipes of your custom recipe type. ```GTRecipeModifiers.PARALLEL_HATCH``` will enable Multiblock Machines to parallelize recipes of your custom type via an optional Parallel Hatch, while ```GTRecipeModifiers.ELECTRIC_OVERCLOCK```will define how your recipes overclock in electric machines and multiblocks.
+2. Max Item Inputs, Max Item Outputs, Max Fluid Inputs, Max Fluid Outputs
+3. A list of available ```GuiTextures``` and ```FillDirection```s can be found in the GTCEu Modern Github, or in the .jar file.
 
 
 ```js title="test_kinetic_recipe_type.js"


### PR DESCRIPTION
Improved the documentation regarding:

1. Correcting how to define a simple electric machine (Pollution is a thing now)
2. Correcting how recipeModifiers are supposed to be defined for custom RecipeTypes
3. How to add tooltips to Multiblock Machine Controllers

Please advise on further corrections (I am unsure if pollution is emitted from machine only when recipe is completed, or on every tick of operation).